### PR TITLE
Add GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+#  schedule:
+#    - cron: '42 5 * * *'
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11"]
+
+    runs-on: ${{matrix.runner}}
+    name: OS ${{matrix.runner}} Python ${{matrix.python-version}}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        # pip install -r requirements.txt
+        pip install pytest
+
+    - name: Check Python version
+      run: python -V
+
+    - name: Test with pytest
+      run: pytest -vs
+


### PR DESCRIPTION
to run the tests on every push and every pull-request on 3 different platforms.

Currently this fails due to #4, but having this will help you fix that issue and get notified when that, or something else breaks again.

This is BTW, part of my [Daily CI](https://dev.to/szabgab/the-2022-december-ci-challenge-5dof) project